### PR TITLE
report errors to users when managing pools

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,12 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception, unless: -> { request.format.json? }
   before_action :authz!
+
+  def log_error(exception)
+    logger.error(
+      "\n\n#{exception.class} (#{exception.message}):\n" +
+      Rails.backtrace_cleaner.clean(exception.backtrace).join("\n") +
+      "\n"
+    )
+  end
 end

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -22,10 +22,14 @@ class PoolsController < ApplicationController
       @errors = @pool.errors.full_messages
       render status: :bad_request
     end
+  rescue
+    handle_error($!)
   end
 
   def edit
     @pool = Pool.find(params[:id])
+  rescue
+    handle_error($!)
   end
 
   def update
@@ -36,15 +40,24 @@ class PoolsController < ApplicationController
       @errors = @pool.errors.full_messages
       render status: :bad_request
     end
+  rescue
+    handle_error($!)
   end
 
   def destroy
     @pool = Pool.find(params[:id])
     @pool.destroy
+  rescue
+    handle_error($!)
   end
 
   private
   def pool_params
     params.require(:pool).permit(:name, :resource, :active, :note)
+  end
+
+  def handle_error(e)
+    @errors = [e.inspect]
+    log_error(e)
   end
 end

--- a/app/views/pools/update.js.erb
+++ b/app/views/pools/update.js.erb
@@ -1,5 +1,5 @@
 <%= render(:partial => "error") %>
 
-<% if @pool.valid? && @pool.persisted? %>
+<% if @pool.valid? && @pool.changed.empty? %>
   <%= smart_listing_item :pools, :update, @pool, "pools/pool" %>
 <% end %>


### PR DESCRIPTION
seems like `save` does in fact raise errors on database failed transaction instead of putting only storing them
