### PR TITLE
Allow user to manage user pools

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -38,6 +38,28 @@ class PoolsController < ApplicationController
     end
   end
 
+  def disable
+    update_params = pool_params
+    update_params[:active] = false
+    @pool = Pool.new(update_params)
+    num_disabled = Pool.
+      where(       name: update_params[:name],
+               resource: update_params[:resource]).
+      update_all(active: update_params[:active],
+             updated_at: Time.now)
+    if num_disabled == 1
+      @persisted = true
+    elsif num_disabled == 0
+      # concurrency issue or not matching name/resource specification
+      @persisted = false
+      @errors = ["conflict with existing pool or not matching name/resource"]
+      render status: :conflict
+    else
+      # this should be impossible
+      raise "Unicorns ate the unique database index?"
+    end
+  end
+
   def destroy
     @pool = Pool.find(params[:id])
     @pool.destroy

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -27,7 +27,9 @@ module AuthHelper
     when :user
       params = request.filtered_parameters
       if params["controller"] == "locks" &&
-          ["create", "update", "lock_from_pool"].include?(params["action"])
+          ["create", "update", "lock_from_pool"].include?(params["action"]) ||
+         params["controller"] == "pools" &&
+          ["disable"].include?(params["action"])
         return
       else
         logger.warn "regular user calling forbidden methods"

--- a/app/views/pools/create.json.ruby
+++ b/app/views/pools/create.json.ruby
@@ -1,0 +1,8 @@
+if @persisted && !(@errors && !@errors.empty?)
+  # success response
+  {name: @pool.name, resource: @pool.resource,
+    active: @pool.active}
+else
+  # something failed
+  { messages: [@errors||=[]].flatten }
+end.to_json

--- a/app/views/pools/disable.json.ruby
+++ b/app/views/pools/disable.json.ruby
@@ -1,0 +1,1 @@
+render template: "pools/create"

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -35,6 +35,9 @@ To create a lock as normal user you can issue the following calls:
 To update a lock as normal user you can issue the following calls:
 <pre><code>curl -v -H "Accept: application/json" -H "Content-type: application/json" -X PATCH -u user:password <%= File.join(root_url, url_for(update_by_values_path)) %> -d '{"namespace":"curl", "resource":"curl_1", "owner":"curl_user", "expires":"1d"}'
 </code></pre>
+To disable a pool as normal user you can issue the following calls:
+<pre><code>curl -v -H "Accept: application/json" -H "Content-type: application/json" -X PATCH -u user:password <%= File.join(root_url, url_for(disable_pool_path)) %> -d '{"name":"curl", "resource":"curl_1"}'
+</code></pre>
 Please note that on update, you should specify all fields although you can only
 update the <code>expites</code> field. This is to avoid unintentional stealing
 of locks. If user is worried of intentional lock stealing, adding a random

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,13 +2,13 @@ Rails.application.routes.draw do
   get 'welcome/index'
   root 'welcome#index'
 
-  resources :locks
+  resources :locks, except: :show
   match '/locks/by_values(.:format)' => 'locks#update', via: [:put, :patch], as: "update_by_values"
   # put   '/locks/by_values(.:format)' => 'locks#update'
 
   post '/locks/from_pool(.:format)' => 'locks#lock_from_pool', as: "create_from_pool"
 
-  resources :pools
-
+  match '/pools/disable(.:format)' => 'pools#disable', via: [:put, :patch], as: "disable_pool"
+  resources :pools, except: :show
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
@akostadinov can you review changes please?
one question: Would it be better to update only those values which were provided with request? For example if `:note` parameter was skipped then **ownthat** will not rewrite its value on empty, WDYT?

PS: will add unit tests soon
